### PR TITLE
Fixes docstrings

### DIFF
--- a/src/clojure/contrib/humanize.clj
+++ b/src/clojure/contrib/humanize.clj
@@ -8,9 +8,10 @@
             [clj-time.local :refer :all]
             [clj-time.coerce :refer :all]))
 
-(defn intcomma [num]
-  " Converts an integer to a string containing commas. every three digits.
-      For example, 3000 becomes '3,000' and 45000 becomes '45,000'. "
+(defn intcomma
+  "Converts an integer to a string containing commas. every three digits.
+   For example, 3000 becomes '3,000' and 45000 becomes '45,000'. "
+  [num]
   (let [
         decimal (abs (int num)) ;;  FIXME: (abs )
         sign (if (< num 0) "-" "")
@@ -31,9 +32,10 @@
     (apply str sign (interpose "," partitioned))))
 
 
-(defn ordinal [num]
+(defn ordinal
   "Converts an integer to its ordinal as a string. 1 is '1st', 2 is '2nd',
-    3 is '3rd', etc."
+   3 is '3rd', etc."
+  [num]
     (let [ordinals ["th", "st", "nd", "rd", "th",
                     "th", "th", "th", "th", "th"]
           remainder-100 (rem num 100)
@@ -48,11 +50,12 @@
   (/ (round (java.lang.Math/log num))
      (round (java.lang.Math/log base))))
 
-(defn intword [num & {:keys [format] :or {format "%.1f"}}]
+(defn intword
   "Converts a large integer to a friendly text representation. Works best for
-    numbers over 1 million. For example, 1000000 becomes '1.0 million', 1200000
-    becomes '1.2 million' and '1200000000' becomes '1.2 billion'.  Supports up to
-    decillion (33 digits) and googol (100 digits)."
+   numbers over 1 million. For example, 1000000 becomes '1.0 million', 1200000
+   becomes '1.2 million' and '1200000000' becomes '1.2 billion'.  Supports up to
+   decillion (33 digits) and googol (100 digits)."
+  [num & {:keys [format] :or {format "%.1f"}}]
   (let [human-pows {
                     0 "",
                     6 " million",
@@ -87,10 +90,11 @@
    19 "nineteen",20 "twenty",30 "thirty",40 "forty",
    50 "fifty",60 "sixty",70 "seventy",80 "eighty",90 "ninety"})
 
-(defn numberword [num]
+(defn numberword
   "Takes a number and return a full written string form. For example,
    23237897 will be written as \"twenty-three million two hundred and
    thirty-seven thousand eight hundred and ninety-seven\".  "
+  [num]
 
   ;; special case for zero
   (if (zero? num)
@@ -126,12 +130,13 @@
      :else                      (join "-" [(numap (* 10 (n-digit num 0)))
                                            (numap (n-digit num 1))])))))
 
-(defn filesize [bytes & {:keys [binary format]
-                         :or {binary false
-                              format "%.1f"}}]
-  " Format a number of byteslike a human readable filesize (eg. 10 kB).  By
-    default, decimal suffixes (kB, MB) are used.  Passing binary=true will use
-    binary suffixes (KiB, MiB) are used. "
+(defn filesize
+  "Format a number of bytes as a human readable filesize (eg. 10 kB). By
+   default, decimal suffixes (kB, MB) are used.  Passing :binary true will use
+   binary suffixes (KiB, MiB) instead."
+  [bytes & {:keys [binary format]
+            :or {binary false
+                 format "%.1f"}}]
 
   (if (zero? bytes)
     ;; special case for zero
@@ -171,11 +176,12 @@
   ([string length]
      (truncate string length "...")))
 
-(defn oxford [coll  & {:keys [maximum-display truncate-noun]
-                       :or {maximum-display 4
-                            truncate-noun nil}}]
+(defn oxford
   "Converts a list of items to a human readable string
    with an optional limit."
+  [coll  & {:keys [maximum-display truncate-noun]
+            :or {maximum-display 4
+                 truncate-noun nil}}]
 
   (let [coll-length (count coll)]
     (cond
@@ -201,12 +207,12 @@
      ;; TODO: shouldn't reach here, throw exception
      :else coll-length)))
 
-(defn datetime [then-dt & {:keys [now-dt suffix]
-                           :or {now-dt (local-now)
-                                suffix  "ago"}}]
-
+(defn datetime 
   "Given a datetime or date, return a human-friendly representation
    of the amount of time elapsed. "
+  [then-dt & {:keys [now-dt suffix]
+              :or {now-dt (local-now)
+                   suffix  "ago"}}]
   (let [then-dt (to-date-time then-dt)
         now-dt  (to-date-time now-dt)
         diff    (interval then-dt now-dt)]


### PR DESCRIPTION
It's just a coincidence that (defn f [args] "docstring" ...) works, but in that case it is part of the expressions in the body of the defn. It should be (defn f "docstring" [args] ...)