### PR TITLE
Removes pluralization rule for "brother"

### DIFF
--- a/src/clojure/contrib/inflect.clj
+++ b/src/clojure/contrib/inflect.clj
@@ -61,7 +61,6 @@
                                {
                                 "ox" "oxen",
                                 "child" "children",
-                                "brother" "brethen",
                                 "man" "men",
                                 "woman" "women",
                                 "foot" "feet",


### PR DESCRIPTION
"Brethren" is an archaic plural form of "brother" and is only used in
religious contexts or fraternal orders. That would be a special case
where a library user could add the exception if needed.