### PR TITLE
Make clojure-humanize compatible with clj-time 0.9.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ pom.xml.asc
 *.class
 /.lein-*
 /.nrepl-port
+.idea/*
+clojure_humanize.iml

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojure-humanize "0.1.0-SNAPSHOT"
+(defproject bilus/clojure-humanize "0.1.0"
   :description "produce human readable strings in clojure"
   :url "https://github.com/trhura/clojure-humanize"
   :license {:name "Eclipse Public License"

--- a/src/clojure/contrib/humanize.clj
+++ b/src/clojure/contrib/humanize.clj
@@ -5,8 +5,8 @@
             [clj-time.core :refer [date-time interval in-seconds
                                    in-minutes in-hours in-days
                                    in-weeks in-months in-years]]
-            [clj-time.local :refer :all]
-            [clj-time.coerce :refer :all]))
+            [clj-time.local :refer [local-now]]
+            [clj-time.coerce :refer [to-date-time to-string]]))
 
 (defn intcomma
   "Converts an integer to a string containing commas. every three digits.


### PR DESCRIPTION
When you use clj-time 0.9.0 in project using clojure-humanize (with `:exclusions [clj-time]`), there are conflicts between `clj-time.local/to-local-date-time` and `clj-time.coerce/to-local-date-time` in the `clojure.contrib.humanize` namespace (due to `:refer :all`).

This patch fixes this.

To recreate the problem, create a project whose :dependencies incude:

```clojure
...
[clj-time "0.9.0"]
[clojure-humanize "0.1.0" :exclusions [clj-time]]
...
```

To see that the fix works without merging changes, change the above to:

```clojure
...
[clj-time "0.9.0"]
[bilus/clojure-humanize "0.1.0-SNAPSHOT" :exclusions [clj-time]]
...
```