### PR TITLE
Added duration function, and other improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ pom.xml.asc
 /.lein-*
 /.nrepl-port
 .idea/*
-clojure_humanize.iml
+*.iml

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,7 @@
+## 0.2.1 - UNRELEASED
+
+`clojure.contrib.inflect/pluralize-noun` now pluralizes a count of zero; previously any count less
+than or equal to 1 was considered singular.
+
+Added `clojure.contrib.humanize/duration` and `duration-terms` to format a duration, in
+milliseconds, as a string.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ __([via Clojars](https://clojars.org/clojure-humanize))__
 * [oxford](#oxford)
 * [pluralize-noun](#pluralize-noun)
 * [datetime](#datetime)
+* [duration](#duration)
 
 ### numberword
 
@@ -152,22 +153,22 @@ user> (clojure.contrib.humanize/oxford ["apple" "orange" "mango" "pear"]
 
 ### pluralize-noun
 
-Return the pluralized noun if the given number is greater than 1.
+Return the pluralized noun if the given number is not 1.
 
 ```clojure
-user> (clojure.contrib.inflect/pluralize-noun 2 "thief" )
+user> (clojure.contrib.inflect/pluralize-noun 2 "thief")
 "thieves"
 
-user> (clojure.contrib.inflect/pluralize-noun 3 "tomato" )
+user> (clojure.contrib.inflect/pluralize-noun 3 "tomato")
 "tomatoes"
 
-user> (clojure.contrib.inflect/pluralize-noun 4 "roof" )
+user> (clojure.contrib.inflect/pluralize-noun 4 "roof")
 "roofs"
 
-user> (clojure.contrib.inflect/pluralize-noun 5 "person" )
+user> (clojure.contrib.inflect/pluralize-noun 5 "person")
 "people"
 
-user> (clojure.contrib.inflect/pluralize-noun 6 "buzz" )
+user> (clojure.contrib.inflect/pluralize-noun 6 "buzz")
 "buzzes"
 
 ```
@@ -175,7 +176,7 @@ user> (clojure.contrib.inflect/pluralize-noun 6 "buzz" )
 ### datetime
 
 Given a datetime or date, return a human-friendly representation
-of the amount of time elapsed.
+of the amount of time elapsed, relative to the current time.
 
 ```clojure
 user> (clojure.contrib.humanize/datetime (plus (now) (seconds -30)))
@@ -186,6 +187,26 @@ user> (clojure.contrib.humanize/datetime (plus (now) (years -20)))
 
 user> (clojure.contrib.humanize/datetime (plus (now) (years -7)))
 "7 years ago"
+
+```
+
+### duration
+
+Given a duration in milliseconds, return a human-friendly
+representation of the amount of time passed.
+
+```clojure
+user> (clojure.contrib.humanize/duration 2000)
+"two seconds"
+
+user> (clojure.contrib.humanize/duration 325100)
+"five minutes, twenty-five seconds"
+
+user> (clojure.contrib.humanize/duration 500)
+"less than a second"
+
+user> (clojure.contrib.humanize/duration 325100 {:number-format str})
+=> "5 minutes, 25 seconds"
 
 ```
 

--- a/project.clj
+++ b/project.clj
@@ -18,4 +18,8 @@
                                    :source-map "target/humanize-test.js.map"}}}
               :test-commands {"cljs" ["phantomjs"
                                       "phantom/unit-test.js"
-                                      "phantom/unit-test.html"]}})
+                                      "phantom/unit-test.html"]}}
+  :aliases {"test-all" ["do"
+                        "test" "clojure.contrib.cljc-test,"
+                        "cljsbuild" "test"
+                        ]})

--- a/project.clj
+++ b/project.clj
@@ -5,9 +5,9 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/math.numeric-tower "0.0.4"]
-                 [clj-time "0.11.0"]
+                 [clj-time "0.12.0"]
                  [com.andrewmcveigh/cljs-time "0.4.0"]]
-  :profiles {:dev {:dependencies [[org.clojure/clojurescript "1.8.51"]]
+  :profiles {:dev {:dependencies [[org.clojure/clojurescript "1.9.93"]]
                    :plugins [[lein-cljsbuild "1.1.3"]]}}
   :cljsbuild {:builds {:test
                        {:source-paths ["src" "test"]

--- a/src/clojure/contrib/humanize.cljc
+++ b/src/clojure/contrib/humanize.cljc
@@ -297,3 +297,75 @@
 
      ;; FIXME:
      :else (to-string diff))))
+
+(def ^:private duration-periods
+  [[(* 1000 60 60 24 365) "year"]
+   [(* 1000 60 60 24 31) "month"]
+   [(* 1000 60 60 24 7) "week"]
+   [(* 1000 60 60 24) "day"]
+   [(* 1000 60 60) "hour"]
+   [(* 1000 60) "minute"]
+   [1000 "second"]])
+
+(defn duration-terms
+  "Converts an duration, in milliseconds, to a set of terms describing the duration.
+  The terms are in descending order, largest period to smallest.
+
+  Each term is a tuple of count and period name, e.g., `[5 \"second\"]`.
+
+  After seconds are accounted for, remaining milliseconds are ignored."
+  {:added "0.2.1"}
+  [elapsed-ms]
+  {:pre [(<= 0 elapsed-ms)]}
+  (loop [remainder elapsed-ms
+         [[period-ms period-name] & more-periods] duration-periods
+         terms []]
+    (cond
+      (nil? period-ms)
+      terms
+
+      (< remainder period-ms)
+      (recur remainder more-periods terms)
+
+      :else
+      (let [period-count (int (/ remainder period-ms))
+            next-remainder (mod remainder period-ms)]
+        (recur next-remainder more-periods
+               (conj terms [period-count period-name]))))))
+
+(defn duration
+  "Converts duration, in milliseconds, into a string describing it in terms
+  of years, months, weeks, days, hours, minutes, and seconds.
+
+  Ex:
+
+     (duration 325100) => \"five minutes, twenty-five seconds\"
+
+  The months and years periods are not based on actual calendar, so are approximate; this
+  function works best for shorter periods of time.
+
+  The optional options map allow some control over the result.
+
+  :list-format (default: a function) can be set to a function such as oxford
+
+  :number-format (default: numberword) function used to format period counts
+
+  :short-text (default: \"less than a second\") "
+  {:added "0.2.1"}
+  ([duration-ms]
+   (duration duration-ms nil))
+  ([duration-ms options]
+   (let [terms (duration-terms duration-ms)
+         {:keys [number-format list-format short-text]
+          :or {number-format numberword
+               short-text "less than a second"
+               ;; This default, instead of oxford, because the entire string is a single "value"
+               list-format #(join ", " %)}} options]
+     (if (seq terms)
+       (->> terms
+            (map (fn [[period-count period-name]]
+                   (str (number-format period-count)
+                        " "
+                        (pluralize-noun period-count period-name))))
+            list-format)
+       short-text))))

--- a/src/clojure/contrib/humanize.cljc
+++ b/src/clojure/contrib/humanize.cljc
@@ -307,17 +307,16 @@
    [(* 1000 60) "minute"]
    [1000 "second"]])
 
-(defn duration-terms
-  "Converts an duration, in milliseconds, to a set of terms describing the duration.
+(defn- duration-terms
+  "Converts a duration, in milliseconds, to a set of terms describing the duration.
   The terms are in descending order, largest period to smallest.
 
   Each term is a tuple of count and period name, e.g., `[5 \"second\"]`.
 
   After seconds are accounted for, remaining milliseconds are ignored."
-  {:added "0.2.1"}
-  [elapsed-ms]
-  {:pre [(<= 0 elapsed-ms)]}
-  (loop [remainder elapsed-ms
+  [duration-ms]
+  {:pre [(<= 0 duration-ms)]}
+  (loop [remainder duration-ms
          [[period-ms period-name] & more-periods] duration-periods
          terms []]
     (cond

--- a/src/clojure/contrib/inflect.cljc
+++ b/src/clojure/contrib/inflect.cljc
@@ -13,6 +13,7 @@
 (defn pluralize-noun [count noun]
   "Return the pluralized noun if the `count' is
    not 1."
+  {:pre [(<= 0 count)]}
   (let [singular? (== count 1)]
     (if singular? noun ;; If singular, return noun
         (some (fn [[cond? result-fn]]

--- a/src/clojure/contrib/inflect.cljc
+++ b/src/clojure/contrib/inflect.cljc
@@ -1,4 +1,5 @@
 (ns clojure.contrib.inflect
+  "Functions and rules for pluralizing nouns."
   (:require [clojure.string :refer [ends-with?]]))
 
 (defn in? [x coll]
@@ -11,8 +12,8 @@
 
 (defn pluralize-noun [count noun]
   "Return the pluralized noun if the `count' is
-   greater than 1."
-  (let [singular? (<= count 1)]
+   not 1."
+  (let [singular? (== count 1)]
     (if singular? noun ;; If singular, return noun
         (some (fn [[cond? result-fn]]
                 (if (cond? noun)
@@ -99,6 +100,7 @@
                                 "zero" "zeroes",
                                 "echo" "echoes",
                                 "banjo" "banjoes",
+                                "cactus" "cactuses"
                                 }
                                )
 
@@ -118,3 +120,4 @@
                                 "plankton" "plankton",
                                 "squid" "squid",
                                 })
+

--- a/test/clojure/contrib/humanize_test.cljc
+++ b/test/clojure/contrib/humanize_test.cljc
@@ -3,7 +3,8 @@
                :cljs [cljs.test :refer-macros [deftest testing is are]])
             [clojure.contrib.humanize :refer [intcomma ordinal intword numberword
                                               filesize truncate oxford datetime
-                                              duration-terms duration]]
+                                              duration]
+             :as h]
             [clojure.contrib.inflect :refer [pluralize-noun]]
             #?(:clj [clojure.math.numeric-tower :refer [expt]])
             #?(:clj  [clj-time.core  :refer [now from-now seconds minutes
@@ -198,7 +199,7 @@
 
 (deftest durations
   (testing "duration to terms"
-    (are [duration terms] (= terms (duration-terms duration))
+    (are [duration terms] (= terms (#'h/duration-terms duration))
                           ;; Less than a second is ignored
                           0 []
                           999 []

--- a/test/clojure/contrib/humanize_test.cljc
+++ b/test/clojure/contrib/humanize_test.cljc
@@ -1,6 +1,6 @@
 (ns clojure.contrib.humanize-test
   (:require #?(:clj  [clojure.test :refer :all]
-               :cljs [cljs.test :refer-macros [deftest testing is]])
+               :cljs [cljs.test :refer-macros [deftest testing is are]])
             [clojure.contrib.humanize :refer [intcomma ordinal intword numberword
                                               filesize truncate oxford datetime
                                               duration-terms duration]]

--- a/test/clojure/contrib/inflect_test.cljc
+++ b/test/clojure/contrib/inflect_test.cljc
@@ -13,9 +13,9 @@
 
   (testing "Zero is considered plural"
     (are [noun expected-noun] (= expected-noun (pluralize-noun 0 noun))
-               "kiss" "kisses"
-               "robot" "robots"
-                "ox" "oxen"))
+                              "kiss" "kisses"
+                              "robot" "robots"
+                              "ox" "oxen"))
 
   (testing "Testing nouns ending in a sibilant sound."
     (is (= (pluralize-noun 2 "kiss") "kisses"))

--- a/test/clojure/contrib/inflect_test.cljc
+++ b/test/clojure/contrib/inflect_test.cljc
@@ -1,9 +1,22 @@
 (ns clojure.contrib.inflect-test
   (:require #?(:clj  [clojure.test :refer :all]
-               :cljs [cljs.test :refer-macros [deftest testing is]])
+               :cljs [cljs.test :refer-macros [deftest testing is are]])
             [clojure.contrib.inflect :refer [pluralize-noun]]))
 
 (deftest pluralize-noun-test
+
+  (testing "A count of one returns the standard value"
+    (are [noun] (= noun (pluralize-noun 1 noun))
+                "kiss"
+                "robot"
+                "ox"))
+
+  (testing "Zero is considered plural"
+    (are [noun expected-noun] (= expected-noun (pluralize-noun 0 noun))
+               "kiss" "kisses"
+               "robot" "robots"
+                "ox" "oxen"))
+
   (testing "Testing nouns ending in a sibilant sound."
     (is (= (pluralize-noun 2 "kiss") "kisses"))
     (is (= (pluralize-noun 2 "phase") "phases"))
@@ -30,7 +43,8 @@
     (is (= (pluralize-noun 2 "pencil") "pencils")))
 
   (testing "Testing irregulars nouns"
-    (is (= (pluralize-noun 2 "ox") "oxen"))
-    (is (= (pluralize-noun 2 "moose") "moose"))
-    (is (= (pluralize-noun 2 "hero") "heroes")))
-  )
+    (are [noun expected-noun] (= expected-noun (pluralize-noun 2 noun))
+                              "ox" "oxen"
+                              "moose" "moose"
+                              "hero" "heroes"
+                              "cactus" "cactuses")))


### PR DESCRIPTION
This adds `duration` for presenting an elapsed duration, in milliseconds.

I noticed that pluralize wasn't quite right as well, it should pluralize anything not 1.  I've updated the code and tests.