### PR TITLE
Exclude words ending with 'ff' from rule 'f -> ves'

### DIFF
--- a/src/clojure/contrib/inflect.cljc
+++ b/src/clojure/contrib/inflect.cljc
@@ -59,7 +59,8 @@
                          (fn [noun] (str noun "es")))
 
 (add-pluralize-noun-rule "For nouns ending with `f', suffixes `ves'"
-                         (fn [noun] (ends-with? noun "f"))
+                         (fn [noun] (and (ends-with? noun "f")
+                                         (not (ends-with? noun "ff"))))
                          (fn [noun] (str (-> noun butlast clojure.string/join) "ves")))
 
 (add-pluralize-noun-rule "For nouns ending with `fe', suffixes `ves'"

--- a/test/clojure/contrib/inflect_test.cljc
+++ b/test/clojure/contrib/inflect_test.cljc
@@ -33,7 +33,8 @@
     (is (= (pluralize-noun 2 "life") "lives"))
     (is (= (pluralize-noun 2 "thief") "thieves"))
     (is (= (pluralize-noun 2 "chief") "chiefs"))
-    (is (= (pluralize-noun 2 "roof") "roofs")))
+    (is (= (pluralize-noun 2 "roof") "roofs"))
+    (is (= (pluralize-noun 2 "staff") "staffs")))
 
   (testing "Testing general nouns."
     (is (= (pluralize-noun 2 "car") "cars"))


### PR DESCRIPTION
I'm not a native English speaker and so not confident this is true, but it doesn't seem that 'f -> ves' rule can be applied to words ending with 'ff'.

e.g:
- staff -> staffs
- muff -> muffs