### PR TITLE
Prevent numberword adding an extra 'zero'

### DIFF
--- a/src/clojure/contrib/humanize.cljc
+++ b/src/clojure/contrib/humanize.cljc
@@ -133,23 +133,29 @@
 
     (cond
      ;; handle million part
-     (>= digitcnt 6)    (join " " [(numberword (int (/ num 1000000)))
-                                  "million"
-                                  (numberword (rem num 1000000))])
+     (>= digitcnt 6)    (if (divisible? num 1000000)
+                           (join " " [(numberword (int (/ num 1000000)))
+                                      "million"])
+                           (join " " [(numberword (int (/ num 1000000)))
+                                       "million"
+                                       (numberword (rem num 1000000))]))
 
      ;; handle thousand part
-     (>= digitcnt 3)    (join " " [(numberword (int (/ num 1000)))
-                                   "thousand"
-                                   (numberword (rem num 1000))])
+     (>= digitcnt 3)    (if (divisible? num 1000)
+                            (join " " [(numberword (int (/ num 1000)))
+                                       "thousand"])
+                            (join " " [(numberword (int (/ num 1000)))
+                                       "thousand"
+                                       (numberword (rem num 1000))]))
 
      ;; handle hundred part
      (>= digitcnt 2)    (if (divisible? num 100)
-                          (join " " [(numap (int (/ num 100)))
-                                     "hundred"])
-                          (join " " [(numap (int (/ num 100)))
-                                     "hundred"
-                                     "and"
-                                     (numberword (rem num 100))]))
+                            (join " " [(numap (int (/ num 100)))
+                                       "hundred"])
+                            (join " " [(numap (int (/ num 100)))
+                                       "hundred"
+                                       "and"
+                                       (numberword (rem num 100))]))
 
      ;; handle the last two digits
      (< num 20)                 (numap num)

--- a/test/clojure/contrib/humanize_test.cljc
+++ b/test/clojure/contrib/humanize_test.cljc
@@ -66,12 +66,15 @@
                               [12 "twelve"]
                               [40 "forty"]
                               [94 "ninety-four"]
+                              [100 "one hundred"]
                               [51 "fifty-one"]
                               [234 "two hundred and thirty-four"]
+                              [1000 "one thousand"]
                               [3567 "three thousand five hundred and sixty-seven"]
                               [44120 "forty-four thousand one hundred and twenty"]
                               [25223 "twenty-five thousand two hundred and twenty-three"]
                               [5223 "five thousand two hundred and twenty-three"]
+                              [1000000 "one million"]
                               [23237897 "twenty-three million two hundred and thirty-seven thousand eight hundred and ninety-seven"]]]
       ;; default argument
       (is (= (numberword testnum) result)))))


### PR DESCRIPTION
This occurred on 1000 and 1000000; the current version does this:
1000        => 'one thousand zero'
1000000 => 'one million zero'

The superfluous zero has now been removed, and tests added to catch this case.

There's a bit of duplication going on in the divisible checks now, but I think it's pretty readable in this format.