### PR TITLE
Add minimal deps.edn for git dep support

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,5 @@
+{:paths ["src"]
+ :deps {org.clojure/clojure {:mvn/version "1.11.1"}
+        org.clojure/math.numeric-tower {:mvn/version "0.0.5"}
+        clj-time/clj-time {:mvn/version "0.15.2"}
+        com.andrewmcveigh/cljs-time {:mvn/version "0.5.2"}}}


### PR DESCRIPTION
We are dependent on some unreleased changes, so we forked this and added a deps.edn.

For us, we can just depend on this fork until you decide to release the latest changes, and then switch back to the official release. But if you would like to support git dependencies, this should do the trick.